### PR TITLE
Issue 1 - Adicionar método de pirâmide de Imagens

### DIFF
--- a/funcs.c
+++ b/funcs.c
@@ -118,11 +118,20 @@ void alg_cross_corr(struct Image src, struct Image sub, int* p){
 void alg_MSE(struct Image src, struct Image sub, int* p){
     unsigned menor_mse = UINT_MAX;
 
+    #ifdef OPTIMIZER
+    double ratio = (1 - sub.width/((double) src.width));
+    int sub_width = sub.width * ratio;
+    int sub_height = sub.height * ratio;
+    #else
+    int sub_width = sub.width;
+    int sub_height = sub.height;
+    #endif
+
     for (int i = 0; i < src.height - sub.height + 1; i++) {
       for (int j = 0; j < src.width - sub.width + 1; j++) {
         unsigned mse = 0;
-        for (int a = 0; a < sub.height; a++) {
-          for (int b = 0; b < sub.width; b++) {
+        for (int a = 0; a < sub_height; a++) {
+          for (int b = 0; b < sub_width; b++) {
             int index = (i + a) * src.width + (j + b);
             mse += uPowOf2(src.Data[index] - sub.Data[a * sub.width + b]);
           }
@@ -136,7 +145,7 @@ void alg_MSE(struct Image src, struct Image sub, int* p){
         #ifdef OPTIMIZER
         else
         {
-            j += sqrt(mse)/((float) sub.width*sub.width)*(sub.width*0.1);
+            j += sqrt(mse)/(sub.width*sub.height)*(sub.width*0.1);
         }
         #endif
       }


### PR DESCRIPTION
# Issue 1 - Adicionar método de Pirâmide de Imagens

## Descrição

Adicionado no otimizador o método de pirâmide de imagens. A proporção é calculada com base na proporção da largura da subimagem para a largura da imagem.

## Alterações

```c
void alg_MSE(struct Image src, struct Image sub, int* p){
    #ifdef OPTIMIZER
    double ratio = (1 - sub.width/((double) src.width));
    int sub_width = sub.width * ratio;
    int sub_height = sub.height * ratio;
    #endif
    ...
}
```

## Testes

Foram geradas subimagens a partir da imagem img04_ORIGINAL.pgm na pasta outros. Esses foram os resultados:

100 imagens 50x50
Acurácia (sem tolerância): **100%**
Precisão Média: **100%**
Tempo Total: **4 min**

100 imagens 400x400
Acurácia (sem tolerância): **100%**
Precisão Média: **100%**
Tempo Total: **1 min**

Para os parâmetros do primeiro teste, o algoritmo original executava em 15 min. Ou seja, houve uma redução significativa do tempo. Por conta das medidas pequenas, o algoritmo otimizado não fez uma redução grande das subimagens para não reduzir a acurácia.

Para os parâmetros do segundo teste, o algoritmo otimizado conseguiu usar mais de seu potencial. O algoritmo original executaria isso em 20 minutos.